### PR TITLE
Feature/semaphore timeout

### DIFF
--- a/io4edge_client/core/protobufcom/pbcoreclient.py
+++ b/io4edge_client/core/protobufcom/pbcoreclient.py
@@ -14,8 +14,6 @@ class PbCoreClient:
     @param command_timeout: timeout for commands in seconds
     """
 
-    _client: BaseClient | None = None
-
     def __init__(self, addr: str, command_timeout=5):
         self._addr = addr
         self._command_timeout = command_timeout
@@ -32,25 +30,6 @@ class PbCoreClient:
         finally:
             self._client.close()
             self._client = None
-
-    @contextmanager
-    def connection(self):
-        """
-        Context manager for the connection.
-
-        Note
-            It suppresses the output of the BaseClient to avoid cluttering the console.
-        """
-        original_stdout = sys.stdout
-        sys.stdout = open(os.devnull, 'w')
-
-        self._client = BaseClient("_io4edge-core._tcp", self._addr)
-        try:
-            yield
-        finally:
-            self._client.close()
-            self._client = None
-            sys.stdout = original_stdout
 
     def command(self, cmd, response):
         """

--- a/io4edge_client/core/protobufcom/pbcoreclient.py
+++ b/io4edge_client/core/protobufcom/pbcoreclient.py
@@ -14,6 +14,8 @@ class PbCoreClient:
     @param command_timeout: timeout for commands in seconds
     """
 
+    _client: BaseClient | None = None
+
     def __init__(self, addr: str, command_timeout=5):
         self._addr = addr
         self._command_timeout = command_timeout
@@ -30,6 +32,25 @@ class PbCoreClient:
         finally:
             self._client.close()
             self._client = None
+
+    @contextmanager
+    def connection(self):
+        """
+        Context manager for the connection.
+
+        Note
+            It suppresses the output of the BaseClient to avoid cluttering the console.
+        """
+        original_stdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+
+        self._client = BaseClient("_io4edge-core._tcp", self._addr)
+        try:
+            yield
+        finally:
+            self._client.close()
+            self._client = None
+            sys.stdout = original_stdout
 
     def command(self, cmd, response):
         """

--- a/io4edge_client/version.py
+++ b/io4edge_client/version.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifer: Apache-2.0
-version = (1, 6, 0)
+version = (1, 6, 1)
 VERSION = "%d.%d.%d" % version


### PR DESCRIPTION
The acquisition of the semaphore during read stream needs a timeout exception because otherwise it is blocking indefinetly.

This is a problem if multiple clients are used to read data from different stream channels within a generator function which should be used to listen for e.g. button press events:

With

```python
with up.read() as up_stream, down.read() as down_stream:
    for up_data, down_data in itertools.zip_longest(
        up_stream, down_stream, fillvalue=False
    ):
        if up_data:
            print("Up button pressed")
        if down_data:
            print("Down button pressed")
```

and 

```python
@contextmanager
    def read(self):
        """
        Reads the current state of the button array.
        """
        self.client.start_stream(
            binio.Pb.StreamControlStart(
                subscribeChannel=(
                    binio.Pb.SubscribeChannel(
                        channel=self.channel_id,
                        subscriptionType=self.parent.subscriptionType,
                    ),
                )
            ),
            self.parent.stream_cfg,
        )
        try:

            def stream_generator():
                while True:
                    try:
                        data = self.client.read_stream(
                            timeout=0
                        )  # Read new data continuously
                        _, samples = data
                        for sample in samples.samples:
                            if (
                                sample.inputs & self.channel_id + 1
                            ):  # Check if the button is pressed
                                yield True
                            else:
                                yield False
                        yield False
                    except TimeoutError:
                        yield False

            yield stream_generator()

        finally:
            self.client.stop_stream()
```

timeout = 0 is needed for non-blocking acquisition to imediatly quit if no data is available.

Otherwise, only one returned value in the zip (first code block) is available while the other generator still waits for a button event.

To correctly handle this, a proper exception must be raised during acquisition:
```python
        if not self._stream_queue_sema.acquire(timeout=timeout):
            raise TimeoutError("No data available within timeout")
```

**Effects on other use cases have to be checked during review!**