### PR TITLE
context awareness introduced

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,95 @@
+# io4edge-client-python Copilot Instructions
+
+## Architecture Overview
+
+This Python SDK provides client libraries for io4edge devices - intelligent I/O devices connected via network. The codebase follows a layered architecture:
+
+- **Base Layer** (`io4edge_client/base/`): Core networking with mDNS service discovery and socket transport
+- **Functionblock Layer** (`io4edge_client/functionblock/`): Generic function block client with command/stream handling
+- **Device-Specific Clients**: Type-specific implementations (analogintypea, binaryiotypea, etc.)
+- **Generated APIs** (`io4edge_client/api/`): Protobuf definitions and generated Python code
+
+## Key Patterns & Conventions
+
+### Client Architecture Pattern
+All device clients follow this consistent pattern:
+```python
+class Client:
+    def __init__(self, addr: str, command_timeout=5):
+        self._fb_client = FbClient("_io4edge_<device_type>._tcp", addr, command_timeout)
+```
+
+Each client wraps a `functionblock.Client` instance and provides device-specific methods. See `analogintypea/client.py` as the canonical example.
+
+### Service Naming Convention
+- mDNS services: `_io4edge_<functionblock>._tcp` (e.g., `_io4edge_analogInTypeA._tcp`)
+- Address format: either mDNS name (e.g., "S101-IOU01-USB-EXT-1") or IP:port ("192.168.1.100:9999")
+
+### Configuration & Control Methods
+Standard methods across all clients:
+- `upload_configuration(config)` / `download_configuration()` - Device configuration
+- `function_control_set()` / `function_control_get()` - Runtime control/status
+- `start_stream()` / `stop_stream()` / `read_stream()` - Data streaming
+- `close()` - Cleanup and thread termination
+
+### Protobuf Integration
+- Import protobuf modules as `Pb` alias: `import ...analogInTypeA_pb2 as Pb`
+- Use `google.protobuf.any_pb2.Any` for generic message wrapping
+- Protobuf files generated from `io4edge_client/api/` subdirectory
+
+## Development Workflows
+
+### Adding New Device Support
+1. Create new module directory under `io4edge_client/`
+2. Implement `Client` class following the established pattern
+3. Import device-specific protobuf as `Pb`
+4. Add example usage in `examples/<device_type>/`
+5. Ensure service name follows `_io4edge_<type>._tcp` convention
+
+### Stream Handling Pattern
+Streaming uses producer-consumer pattern with background thread:
+```python
+# Producer thread reads socket, queues messages
+# Consumer calls read_stream() with optional timeout
+generic_data, specific_data = client.read_stream(timeout=1.0)
+```
+
+### Testing
+- Unit tests in `tests/` focus on parsing and address handling
+- Integration examples in `examples/` serve as functional tests
+- Use `python -m unittest` for running tests
+
+## Critical Implementation Details
+
+### Thread Safety
+- `functionblock.Client` uses internal threading for stream handling
+- Always call `close()` to properly terminate background threads
+- Command/response uses mutex protection for single-command-at-a-time
+
+### Error Handling
+- Commands raise `RuntimeError` for protocol errors
+- `TimeoutError` for command timeouts (default 5 seconds)
+- Stream reads raise `TimeoutError` when no data available
+
+### Address Resolution
+Base client automatically handles:
+- Direct IP:port addresses: `"192.168.1.100:9999"`
+- mDNS service names: `"S101-IOU01-USB-EXT-1"` (automatically appends service type)
+
+## Protobuf Code Generation
+
+The `io4edge_client/api/` directory contains a git submodule with protobuf definitions. Use `make` in that directory to regenerate Python protobuf code when proto files change.
+
+## Docker Deployment
+
+For containerized deployment, use host networking mode to access mDNS services:
+```bash
+docker run --network=host <image> <script-args>
+```
+
+## Common Pitfalls
+
+- Always use absolute imports for protobuf modules to avoid conflicts
+- Call `client.close()` in cleanup/exception handlers to prevent thread leaks
+- Check device-specific protobuf documentation for field constraints
+- Service discovery requires network connectivity to device's mDNS announcements

--- a/io4edge_client/base/client.py
+++ b/io4edge_client/base/client.py
@@ -5,14 +5,14 @@ from .socket_transport import SocketTransport
 
 class Client:
     def __init__(self, service: str, addr: str, connect=True):
-         # detect if addr is a service name or an IP address
+        # detect if addr is a service name or an IP address
         try:
-            ip, port = self._net_address_split(self._addr)
+            ip, port = self._net_address_split(addr)
         except ValueError:
             # addr may be a service name
-            ip, port = self._find_mdns(self._addr + "." + self._service)
+            ip, port = self._find_mdns(addr + "." + service)
 
-        #print(f"Connecting to {ip}:{port}")
+        # print(f"Connecting to {ip}:{port}")
         if ip is None:
             raise RuntimeError("service not found")
 
@@ -38,13 +38,13 @@ class Client:
         """
         Marshall msg and write it to the server
         """
+        data = msg.SerializeToString()
+
         if not self.connected:
             with self._transport as t:
-                data = msg.SerializeToString()
                 t.write(data)
                 return
 
-        data = msg.SerializeToString()
         self._transport.write(data)
 
     def read_msg(self, msg, timeout):

--- a/io4edge_client/base/client.py
+++ b/io4edge_client/base/client.py
@@ -4,21 +4,46 @@ from .socket_transport import SocketTransport
 
 
 class Client:
-    def __init__(self, service: str, addr: str):
-        # detect if addr is a service name or an IP address
+    def __init__(self, service: str, addr: str, connect=True):
+         # detect if addr is a service name or an IP address
         try:
-            ip, port = self._net_address_split(addr)
+            ip, port = self._net_address_split(self._addr)
         except ValueError:
             # addr may be a service name
-            ip, port = self._find_mdns(addr + "." + service)
+            ip, port = self._find_mdns(self._addr + "." + self._service)
 
-        # print(f"Connecting to {ip}:{port}")
-        self._transport = SocketTransport(ip, port)
+        #print(f"Connecting to {ip}:{port}")
+        if ip is None:
+            raise RuntimeError("service not found")
+
+        self._transport = SocketTransport(ip, port, connect)
+
+    @property
+    def connected(self):
+        return self._transport is not None and self._transport.connected
+
+    def open(self):
+        if self.connected:
+            return
+        self._transport.open()
+
+    def __enter__(self):
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
     def write_msg(self, msg):
         """
         Marshall msg and write it to the server
         """
+        if not self.connected:
+            with self._transport as t:
+                data = msg.SerializeToString()
+                t.write(data)
+                return
+
         data = msg.SerializeToString()
         self._transport.write(data)
 
@@ -28,6 +53,11 @@ class Client:
         Pass msg as a protobuf message type with the expected type.
         If timeout is not None, raise TimeoutError if no message is received within timeout seconds.
         """
+        if not self.connected:
+            with self._transport as t:
+                data = t.read(timeout)
+                msg.ParseFromString(bytes(data))
+                return
         data = self._transport.read(timeout)
         msg.ParseFromString(bytes(data))
 

--- a/io4edge_client/base/socket_transport.py
+++ b/io4edge_client/base/socket_transport.py
@@ -5,11 +5,34 @@ import select
 
 
 class SocketTransport:
-    def __init__(self, host, port):
-        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-        s.connect((host, port))
-        self._socket = s
+    def __init__(self, host, port, connect=True):
+        self._host = host
+        self._port = port
+        self._socket = None
+        if connect:
+            self.open()
+
+    def __enter__(self):
+        if self._socket is None:
+            self.open()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self._socket is not None:
+            self.close()
+            self._socket = None
+
+    def open(self):
+        if self._socket is None:
+            self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+            self._socket.connect((self._host, self._port))
+            return self
+        return
+
+    @property
+    def connected(self):
+        return self._socket is not None
 
     def write(self, data: bytes) -> int:
         """

--- a/io4edge_client/base/socket_transport.py
+++ b/io4edge_client/base/socket_transport.py
@@ -20,7 +20,6 @@ class SocketTransport:
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self._socket is not None:
             self.close()
-            self._socket = None
 
     def open(self):
         if self._socket is None:
@@ -70,3 +69,4 @@ class SocketTransport:
 
     def close(self):
         self._socket.close()
+        self._socket = None


### PR DESCRIPTION
## Context awareness is introduced in a compatible way with the former behaviour

Now, tcp socket connections as well as the base client can be used by all FB clients in three ways:

### Open connection upon device init

This is the way it was used before these changes.
It still works! :)

### Open connection manually
Base client and SocketTransport now have an `open()` method in addition to their `close()` opposites.

Any BaseClient connection opened will open a new TCP socket in SocketTransport if it is not already opened.

If a connection is not used anymore, the socket can be closed, but the SocketTransport object is still usable if calling `open()` again.

### Use context aware syntax

BaseClient and SocketTransport can be used using the `with ` statement:

```python
client = transport = SocketTransport(ip, port)

with client as t:
    t.write(<data>)
```

This way, a connection is automatically opened (if not already connected) and closed after context ends.

## BaseClient and SocketTransport can be initialised without auto connect

Just use `connect=False` in object instanciation.

## Example class using new behaviour

See core client.

Fix #24 #25 
