### PR TITLE
Refactor/leds

### DIFF
--- a/io4edge_client/colorLED/client.py
+++ b/io4edge_client/colorLED/client.py
@@ -66,6 +66,12 @@ class Client(ClientConnection):
             self._check_rgb_range(color)
             fs_cmd.rgb.CopyFrom(color)
         elif isinstance(color, tuple) and len(color) == 3:
+            # Ensure tuple components are plain integers (excluding bool) before assignment
+            for c in color:
+                if isinstance(c, bool) or not isinstance(c, int):
+                    raise ValueError(
+                        "RGB tuple components must be integers between 0 and 255"
+                    )
             self._check_rgb_range(color)
             fs_cmd.rgb.red, fs_cmd.rgb.green, fs_cmd.rgb.blue = color
         elif isinstance(color, str) and color.startswith("#") \

--- a/io4edge_client/colorLED/client.py
+++ b/io4edge_client/colorLED/client.py
@@ -78,10 +78,18 @@ class Client(ClientConnection):
                 fs_cmd.rgb.red = r
                 fs_cmd.rgb.green = g
                 fs_cmd.rgb.blue = b
-            except ValueError:
-                raise ValueError("Invalid color format")
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid hex color string {color!r}. Expected format "
+                    "'#RRGGBB' with hexadecimal digits."
+                ) from e
         else:
-            raise ValueError("Invalid color type")
+            raise ValueError(
+                "Invalid color parameter of type "
+                f"{type(color).__name__}: {color!r}. Expected one of: "
+                "Pb.Color, Pb.RGBColor, a (r, g, b) tuple of ints 0–255, "
+                "or a '#RRGGBB' hex color string."
+            )
         fs_cmd.blink = blink
         self._client.function_control_set(
             fs_cmd, Pb.FunctionControlSetResponse()

--- a/io4edge_client/colorLED/client.py
+++ b/io4edge_client/colorLED/client.py
@@ -60,7 +60,7 @@ class Client(ClientConnection):
         """
         fs_cmd = Pb.FunctionControlSet()
         fs_cmd.channel = channel
-        if isinstance(color, Pb.Color):
+        if isinstance(color, int) and color in Pb.Color.values():
             fs_cmd.color = color
         elif isinstance(color, Pb.RGBColor):
             self._check_rgb_range(color)

--- a/io4edge_client/colorLED/client.py
+++ b/io4edge_client/colorLED/client.py
@@ -104,12 +104,12 @@ class Client(ClientConnection):
 
     def _check_rgb_range(self, color: Pb.RGBColor | Tuple[int, int, int]) -> None:
         if isinstance(color, Pb.RGBColor):
-            for c in (color.red, color.green, color.blue):
-                if not (0 <= c <= 255):
-                    raise ValueError("RGB color values must be in the range 0-255")
+            components = (color.red, color.green, color.blue)
         elif isinstance(color, tuple) and len(color) == 3:
-            for c in color:
-                if not (0 <= c <= 255):
-                    raise ValueError("RGB color values must be in the range 0-255")
+            components = color
         else:
             raise ValueError("Invalid color type")
+
+        for c in components:
+            if not (0 <= c <= 255):
+                raise ValueError("RGB color values must be in the range 0-255")

--- a/io4edge_client/colorLED/client.py
+++ b/io4edge_client/colorLED/client.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+from tabnanny import check
 from typing import Tuple, Any
 from io4edge_client.base.connections import ClientConnection, connectable
 from io4edge_client.base.logging import io4edge_client_logger
@@ -42,29 +43,39 @@ class Client(ClientConnection):
         return fs_response
 
     @connectable
-    def set(self, channel: int, color: Pb.Color, blink: bool) -> None:
+    def set(self, channel: int, color: Pb.Color | Pb.RGBColor | Tuple[int, int, int], blink: bool) -> None:
         """
         Set the state of a single output.
         @param channel: channel number
-        @param color: color to set
+        @param color: color to set as Pb.Color, Pb.RGBColor, or a tuple of (red, green, blue) values
         @param blink: if true the LED should blink
         @raises RuntimeError: if the command fails
         @raises TimeoutError: if the command times out
+        @raises ValueError: if the color parameter is invalid or values are out of range
         """
         fs_cmd = Pb.FunctionControlSet()
         fs_cmd.channel = channel
-        fs_cmd.color = color
+        if isinstance(color, Pb.Color):
+            fs_cmd.color = color
+        elif isinstance(color, Pb.RGBColor):
+            self._check_rgb_range(color)
+            fs_cmd.rgb.CopyFrom(color)
+        elif isinstance(color, tuple) and len(color) == 3:
+            self._check_rgb_range(color)
+            fs_cmd.rgb.red, fs_cmd.rgb.green, fs_cmd.rgb.blue = color
+        else:
+            raise ValueError("Invalid color type")
         fs_cmd.blink = blink
         self._client.function_control_set(
             fs_cmd, Pb.FunctionControlSetResponse()
         )
 
     @connectable
-    def get(self, channel: int) -> Tuple[Any, bool]:
+    def get(self, channel: int) -> Tuple[int, int, int, bool]:
         """
         Get the state of a single channel.
         @param channel: channel number
-        @return: LED color and blink state
+        @return: LED color and blink state as a tuple (red, green, blue, blink)
         @raises RuntimeError: if the command fails
         @raises TimeoutError: if the command times out
         """
@@ -72,4 +83,16 @@ class Client(ClientConnection):
         fs_cmd.channel = channel
         fs_response = Pb.FunctionControlGetResponse()
         self._client.function_control_get(fs_cmd, fs_response)
-        return fs_response.color, fs_response.blink
+        return fs_response.rgb.red, fs_response.rgb.green, fs_response.rgb.blue, fs_response.blink
+
+    def _check_rgb_range(self, color: Pb.RGBColor | Tuple[int, int, int]) -> None:
+        if isinstance(color, Pb.RGBColor):
+            for c in (color.red, color.green, color.blue):
+                if not (0 <= c <= 255):
+                    raise ValueError("RGB color values must be in the range 0-255")
+        elif isinstance(color, tuple) and len(color) == 3:
+            for c in color:
+                if not (0 <= c <= 255):
+                    raise ValueError("RGB color values must be in the range 0-255")
+        else:
+            raise ValueError("Invalid color type")

--- a/io4edge_client/functionblock/client.py
+++ b/io4edge_client/functionblock/client.py
@@ -222,7 +222,9 @@ class Client(ClientConnection[BaseClientProtocol], StreamingClientProtocol):
         """
         self._logger.debug("Reading stream data with timeout=%s", timeout)
         if not self._stream_queue_sema.acquire(timeout=timeout):
-            self._logger.warning("Stream read timeout - no data available")
+            self._logger.debug(
+                "Stream read timeout - no data available within %s seconds",
+                timeout)
             raise TimeoutError("No data available within timeout")
         with self._stream_queue_mutex:
             data = self._stream_queue.popleft()

--- a/io4edge_client/version.py
+++ b/io4edge_client/version.py
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
-version = (2, 4, 4)
+version = (2, 4, 5)
 VERSION = "%d.%d.%d" % version


### PR DESCRIPTION
set LED parameter set for color supply supports now:

- RGB values as ints and hex representing strings
- Protobuf RGB message type

checks for values integrated.

Get method always returns rgb value now