### PR TITLE
reduce chance of race condition ocurence during on-demand (dis)connects

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-    "python-envs.pythonProjects": []
+    "python-envs.pythonProjects": [
+        {
+            "path": ".",
+            "envManager": "ms-python.python:venv",
+            "packageManager": "ms-python.python:pip"
+        }
+    ]
 }

--- a/io4edge_client/base/connections.py
+++ b/io4edge_client/base/connections.py
@@ -76,6 +76,10 @@ def connectable(func):
     - Add timeout handling
     - Check client protocol implementation
     - support usage on classes which implement context manager
+
+    Warnings
+    --------
+    This decorator assumes that the class on which it is applied implements the context manager protocol (i.e., has `__enter__` and `__exit__` methods).
     """
 
     @wraps(func)
@@ -83,7 +87,7 @@ def connectable(func):
         if self.connected:
             return func(self, *args, **kwargs)
         else:
-            with self._client:
+            with self:
                 return func(self, *args, **kwargs)
 
     return connect

--- a/io4edge_client/base/connections.py
+++ b/io4edge_client/base/connections.py
@@ -75,7 +75,6 @@ def connectable(func):
     - Add logging
     - Add timeout handling
     - Check client protocol implementation
-    - support usage on classes which implement context manager
 
     Warnings
     --------


### PR DESCRIPTION
Fix possible race condition:

if connection is droppend during a device client connectable decorator call, but after self.connected is evaluated, upstream write_ or read_msg calls in base client try to call self._client with context manager protocol.

Because socket transport is not context manageable, this leads to
`ekfsm:ekfsm.devices.leds-ERROR: Failed to set ColorLED 'led1' on channel 1: 'SocketTransport' object does not support the context manager protocol`